### PR TITLE
Update receivers.py

### DIFF
--- a/care/audit_log/receivers.py
+++ b/care/audit_log/receivers.py
@@ -10,20 +10,20 @@ from django.db.models.signals import post_delete, post_save, pre_delete, pre_sav
 from django.dispatch import receiver
 
 from care.audit_log.enums import Operation
-from care.audit_log.helpers import (
-    LogJsonEncoder,
-    exclude_model,
-    get_model_name,
-    get_or_create_meta,
-    remove_non_member_fields,
-    seperate_hashable_dict,
-)
+from care.audit_log.helpers import (LogJsonEncoder, exclude_model, get_model_name, get_or_create_meta,
+                                    remove_non_member_fields, seperate_hashable_dict)
 from care.audit_log.middleware import AuditLogMiddleware
 
 logger = logging.getLogger(__name__)
 
 Event = NamedTuple(
-    "Event", [("model", str), ("actor", AbstractUser), ("entity_id", Union[int, str]), ("changes", dict)],
+    "Event",
+    [
+        ("model", str),
+        ("actor", AbstractUser),
+        ("entity_id", Union[int, str]),
+        ("changes", dict),
+    ],
 )
 
 
@@ -53,13 +53,16 @@ def pre_save_signal(sender, instance, **kwargs) -> None:
         # __dict__ is used on pre, therefore we need to create a function
         # that uses __dict__ too, but returns nothing.
 
-        pre = lambda _: None
+        def pre(_):
+            return None
+
         operation = Operation.INSERT
 
     changes = {}
 
     if operation not in {Operation.INSERT, Operation.DELETE}:
-        old, new = remove_non_member_fields(pre.__dict__), remove_non_member_fields(instance.__dict__)
+        old, new = remove_non_member_fields(
+            pre.__dict__), remove_non_member_fields(instance.__dict__)
 
         try:
             changes = dict(set(new.items()).difference(old.items()))
@@ -67,10 +70,16 @@ def pre_save_signal(sender, instance, **kwargs) -> None:
             old_hashable, old_non_hashable = seperate_hashable_dict(old)
             new_hashable, new_non_hashable = seperate_hashable_dict(new)
 
-            changes = dict(set(new_hashable.items()).difference(old_hashable.items()))
-            changes.update({k: v for k, v in new_non_hashable.items() if v != old_non_hashable.get(k)})
+            changes = dict(
+                set(new_hashable.items()).difference(old_hashable.items()))
+            changes.update({
+                k: v
+                for k, v in new_non_hashable.items()
+                if v != old_non_hashable.get(k)
+            })
 
-        excluded_fields = settings.AUDIT_LOG["models"]["exclude"]["fields"].get(model_name, [])
+        excluded_fields = settings.AUDIT_LOG["models"]["exclude"][
+            "fields"].get(model_name, [])
         for field in excluded_fields:
             if field in changes:
                 changes[field] = "xxx"
@@ -81,7 +90,10 @@ def pre_save_signal(sender, instance, **kwargs) -> None:
 
     current_user = AuditLogMiddleware.get_current_user()
 
-    instance._meta.dal.event = Event(model=model_name, actor=current_user, entity_id=instance.pk, changes=changes)
+    instance._meta.dal.event = Event(model=model_name,
+                                     actor=current_user,
+                                     entity_id=instance.pk,
+                                     changes=changes)
 
 
 def _post_processor(instance, event: Optional[Event], operation: Operation):
@@ -99,16 +111,20 @@ def _post_processor(instance, event: Optional[Event], operation: Operation):
             if "_state" in changes:
                 del changes["_state"]
         else:
-            changes = json.dumps(event.changes if event else {}, cls=LogJsonEncoder)
+            changes = json.dumps(event.changes if event else {},
+                                 cls=LogJsonEncoder)
     except Exception:
         logger.warning(f"Failed to log {event}", exc_info=True)
         return
 
-    logger.info(f"AUDIT_LOG::{request_id}|{actor}|{operation.value}|{model_name}|ID:{instance.pk}|{changes}")
+    logger.info(
+        f"AUDIT_LOG::{request_id}|{actor}|{operation.value}|{model_name}|ID:{instance.pk}|{changes}"
+    )
 
 
 @receiver(post_save, weak=False)
-def post_save_signal(sender, instance, created, update_fields: frozenset, **kwargs):
+def post_save_signal(sender, instance, created, update_fields: frozenset,
+                     **kwargs):
     if not settings.AUDIT_LOG_ENABLED:
         return
 

--- a/care/audit_log/receivers.py
+++ b/care/audit_log/receivers.py
@@ -99,7 +99,7 @@ def _post_processor(instance, event: Optional[Event], operation: Operation):
             if "_state" in changes:
                 del changes["_state"]
         else:
-            changes = json.dumps(event.changes if event else dict(), cls=LogJsonEncoder)
+            changes = json.dumps(event.changes if event else {}, cls=LogJsonEncoder)
     except Exception:
         logger.warning(f"Failed to log {event}", exc_info=True)
         return


### PR DESCRIPTION
#PERFORMANCE
Consider using literal syntax to create the data structure 
Using the literal syntax can give minor performance bumps compared to using function calls to create dict, list and tuple. 
This is because here, the name dict must be looked up in the global scope in case it has been rebound. Same goes for the other two types list() and tuple().